### PR TITLE
fix(release): patch build deps, group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     schedule:
       # Check for updates to Go modules every weekday
       interval: daily
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: gomod
     directory: /tools
     schedule:
@@ -15,7 +19,15 @@ updates:
     commit-message:
       prefix: ci
       include: scope
+    groups:
+      go-tools:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.releaserc
+++ b/.releaserc
@@ -48,7 +48,7 @@
           },
           {
             "type": "build",
-            "release": "minor"
+            "release": "patch"
           },
           {
             "type": "chore",


### PR DESCRIPTION
## Summary

- **fix(release):** `build(deps)` commits from Dependabot were triggering **minor** releases (v1.3.0 → v1.4.0 per bump) because `.releaserc` mapped `build` → `minor`. Dependency bumps are not user-facing features — changed to `patch`.
- **chore(deps):** Dependabot now groups all updates per ecosystem into a single PR instead of one PR per package. Three groups: `go-dependencies` (root go.mod), `go-tools` (tools/ go.mod), `github-actions`.

## Test plan

- [ ] Existing open Dependabot PRs (individual) can be merged and closed — new grouped PRs will appear on next Dependabot run
- [ ] Verify next Dependabot run creates grouped PRs
- [ ] Verify a merged `build(deps)` bump creates a patch release, not minor