### PR TITLE
fix(ci): move CodeQL to standalone workflow to unblock Dependabot PRs

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,46 @@
+# Copyright Thomas Geens 2025, 2026
+# SPDX-License-Identifier: MIT
+
+# Standalone CodeQL workflow — runs on every PR to main regardless of which
+# files changed. Keeps GitHub Code Scanning enforcement satisfied even for
+# Dependabot PRs that only update workflow files or other non-Go paths.
+name: SAST - CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        with:
+          languages: go
+          config-file: .github/codeql.yml
+
+      - run: go build -v .
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   # Ensure project builds before running testing matrix
@@ -60,22 +59,11 @@ jobs:
           go-version-file: go.mod
           cache: true
       - run: go mod download
-      - name: Static code initialization
-        uses: github/codeql-action/init@v3.28.17
-        with:
-          languages: go
-          config-file: .github/codeql.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@v8.0.0
         with:
           version: latest
-      - name: Static code analysis
-        uses: github/codeql-action/analyze@v3.28.17
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate:
     name: Generate Docs, License, Terraform Reg Manifest


### PR DESCRIPTION
## Summary

CodeQL was embedded in `test.yaml` behind a paths filter. Dependabot PRs that only update workflow files (`.github/workflows/`) didn't match the filter, so CI never ran, CodeQL never completed, and GitHub Code Scanning blocked the merge indefinitely.

**Fix:** dedicate a standalone `codeql.yaml` workflow that triggers on all `pull_request` and `push` events — no path filter. Actions SHA-pinned, `persist-credentials: false`. CodeQL removed from `test.yaml`.

## Test plan

- [ ] Open Dependabot PRs that only touch `.github/workflows/` — CodeQL should now run and complete, unblocking merge