### PR TITLE
fix(ci/generate): use tools/go.mod for Go version in generate jobs

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version-file: tools/go.mod
           cache: true
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6.4.0
         with:
-          go-version-file: go.mod
+          go-version-file: tools/go.mod
           cache: true
       - uses: hashicorp/setup-terraform@v4.0.1
         with:


### PR DESCRIPTION
## Summary

PR #82 (go-tools Dependabot bump) bumped `tools/go.mod` to require Go 1.25.8 while root `go.mod` specifies 1.25.0. Both generate workflows used `go-version-file: go.mod` (root), causing `make generate` to fail with `go.mod requires go >= 1.25.8 (running go 1.25.0)`.

Fixed by using `go-version-file: tools/go.mod` in the generate job (`test.yaml`) and the auto-generate workflow (`generate.yaml`). Build and test jobs keep `go.mod` (root) since they compile the provider, not the tooling.

## Test plan

- [ ] PR #82 CI should pass after this merges to main and the branch is rebased
- [ ] `make generate` in CI uses Go 1.25.8 as required by tools/