### PR TITLE
fix(ci/generate): use GOTOOLCHAIN=auto for flexible Go version in generate

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: tools/go.mod
+          go-version-file: go.mod
           cache: true
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
@@ -38,6 +38,8 @@ jobs:
           terraform_wrapper: false
 
       - run: make generate
+        env:
+          GOTOOLCHAIN: auto
 
       - name: Commit generated docs if changed
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,12 +73,14 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6.4.0
         with:
-          go-version-file: tools/go.mod
+          go-version-file: go.mod
           cache: true
       - uses: hashicorp/setup-terraform@v4.0.1
         with:
           terraform_wrapper: false
       - run: make generate
+        env:
+          GOTOOLCHAIN: auto
       - name: git diff
         run: |
           git diff --compact-summary --exit-code || \


### PR DESCRIPTION
## Summary

PR #84 fixed the wrong problem. The issue is that root \`go.mod\` and \`tools/go.mod\` can independently require different minimum Go versions when Dependabot bumps them separately. A pinned \`go-version-file\` always breaks one side.

**Fix:** revert \`go-version-file\` back to \`go.mod\` (root) and add \`GOTOOLCHAIN=auto\` to the \`make generate\` step. Go's built-in toolchain management downloads the correct version when any \`go.mod\` in scope requires a newer one.

This replaces the approach from PR #84.

## Test plan

- [ ] PR #81 (root go.mod bump to 1.25.8) generate jobs should pass
- [ ] Future tools/ bumps that raise tools/go.mod go version should also pass