### PR TITLE
fix(release): use draftRelease to prevent GoReleaser asset upload conflict

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -87,6 +87,6 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    "@semantic-release/github"
+    ["@semantic-release/github", {"draftRelease": true}]
   ]
 }


### PR DESCRIPTION
## Problem

\`@semantic-release/github\` publishes the GitHub release immediately as part of semantic-release. Then \`call_release\` triggers GoReleaser which fails with \`422 Cannot upload assets to an immutable release\`.

This caused v1.3.1 to be released with **0 assets** — broken for users.

## Fix

\`draftRelease: true\` makes \`@semantic-release/github\` create a draft. GoReleaser's \`--clean\` takes over the draft, adds all assets, then publishes it properly.

## After merging

To repair v1.3.1:
1. Delete the broken v1.3.1 GitHub release (Settings → Releases → Delete)
2. Delete the tag: \`git push origin :refs/tags/1.3.1\`
3. Trigger semantic versioning via workflow_dispatch (dry_run: false) to recreate 1.3.1 cleanly