### PR TITLE
feat: document pre-release version pinning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Full schema, component reference, and cloud-provider examples:
 
 ## Pre-release versions
 
-Pre-release builds (`beta`, `alpha`, `next`) are published to the Terraform Registry for early testing. Open-ended constraints like `~> 1.0` never select them — you must pin the exact version:
+Pre-release builds (`beta`, `alpha`, `next`, `next-major`) are published to the Terraform Registry for early testing. Open-ended constraints like `~> 1.0` never select them — you must pin the exact version:
 
 ```hcl
 terraform {

--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ output "storage_account_name" {
 Full schema, component reference, and cloud-provider examples:
 [registry.terraform.io/providers/thomasgeens/resourcenamingtool](https://registry.terraform.io/providers/thomasgeens/resourcenamingtool/latest/docs)
 
+## Pre-release versions
+
+Pre-release builds (`beta`, `alpha`, `next`) are published to the Terraform Registry for early testing. Open-ended constraints like `~> 1.0` never select them — you must pin the exact version:
+
+```hcl
+terraform {
+  required_providers {
+    resourcenamingtool = {
+      source  = "thomasgeens/resourcenamingtool"
+      version = "1.4.0-beta.1"
+    }
+  }
+}
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#pre-release) for how pre-release channels map to branches.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, commit conventions, and the release process.


### PR DESCRIPTION
Surfaces the pre-release channel feature (shipped 1.3.0) to end users with a registry version-pinning example.

Cut as `feat:` to bump to **1.4.0** — the prior 1.3.1 tag is permanently locked by GitHub's immutable-release ledger and cannot be reused, so the next clean release skips it.